### PR TITLE
Update changeFlag POST req to use req.body instead of req.params

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -13,4 +13,4 @@ app.use(
 app.use(featureFlags);
 app.use(changeFlag);
 
-app.listen(3000);
+app.listen(3001);

--- a/backend/app/clientContoller/clientController.js
+++ b/backend/app/clientContoller/clientController.js
@@ -29,12 +29,12 @@ const getFeatureFlags = async (req, res) => {
  * @param {object} req - Express request object
  * @param {object} res - Express response object
  * @param {function} next - Express next middleware function
- * @description - Calls the changeFlag function of the business layer and sends the request parameters as a response.
+ * @description - Calls the changeFlag function of the business layer and sends the request body as a response.
  * @returns {object} - HTTP response object
  */
 const changeFlag = async (req, res, next) => {
   try {
-    res.send(await business.changeFlag(req.params));
+    res.send(await business.changeFlag(req.body));
   } catch (e) {
     console.log(e.message);
     res.status(400);

--- a/backend/app/featureFlagController/launchDarklyController.js
+++ b/backend/app/featureFlagController/launchDarklyController.js
@@ -29,7 +29,7 @@ async function getFeatureFlags(projectKey = "default") {
  * @function
  * @param {Object} parameters - The parameters for updating the feature flag.
  * @param {string} parameters.key - The key of the feature flag.
- * @param {string} parameters.value - The new value of the feature flag.
+ * @param {boolean} parameters.value - The new value of the feature flag.
  */
 async function changeFlag(parameters) {
   const projectKey = "default";

--- a/backend/app/featureFlagController/launchDarklyController.js
+++ b/backend/app/featureFlagController/launchDarklyController.js
@@ -13,7 +13,7 @@ async function getFeatureFlags(projectKey = "default") {
     {
       method: "GET",
       headers: {
-        Authorization: "api-5380598a-207a-454b-956c-f862ddebc08a",
+        Authorization: "api-b85a475e-50aa-4866-b376-a89bbefa98bb",
       },
     }
   );
@@ -50,7 +50,7 @@ async function changeFlag(parameters) {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        Authorization: "api-5ed283d6-d768-4a27-a478-92dc0f99c6aa",
+        Authorization: "api-b85a475e-50aa-4866-b376-a89bbefa98bb",
       },
       body: JSON.stringify({
         patch: [

--- a/backend/app/featureFlagController/launchDarklyController.js
+++ b/backend/app/featureFlagController/launchDarklyController.js
@@ -29,11 +29,16 @@ async function getFeatureFlags(projectKey = "default") {
  * @function
  * @param {Object} parameters - The parameters for updating the feature flag.
  * @param {string} parameters.key - The key of the feature flag.
- * @param {boolean} parameters.value - The new value of the feature flag.
+ * @param {string} parameters.value - The new value of the feature flag.
  */
 async function changeFlag(parameters) {
   const projectKey = "default";
   const featureFlagKey = parameters.key;
+
+  // Logic to ensure featureFlagValue is passed as a Boolean and not a String in JSON.
+  // If the parameters.value is passed directly into the JSON.stringify statement, or
+  // if the featureFlagValue is assigned the parameters.value, the value will not be boolean
+  // and will be passed as a string.
   let featureFlagValue = false;
   if (parameters.value == "true") {
     featureFlagValue = true;

--- a/backend/app/routes/changeFlag.js
+++ b/backend/app/routes/changeFlag.js
@@ -1,16 +1,18 @@
 /**
  *  Router for changing a feature flag's status.
  */
-
+const bodyParser = require("body-parser");
 const express = require("express");
 const clientController = require("../clientContoller/clientController");
 const router = express.Router();
+router.use(bodyParser.json());
+router.use(express.urlencoded({ extended: true }));
 
 /**
- * @route POST /:key/:value
- * @desc Updates the value of a feature flag with a given key.
+ * @route POST /changeflag
+ * @desc Updates the value of a feature flag with a given key and value.
  * @access
  */
-router.post("/:key/:value", clientController.changeFlag);
+router.post("/changeflag", clientController.changeFlag);
 
 module.exports = router;


### PR DESCRIPTION
### Updates changeFlag POST req
## changeFlag.js
- routing change to /changeflag from /:key/:value
- add bodyParser.json() and express.urlencoded() to router
## clientController.js
- update req.params to req.body
