### PR TITLE
Combine Single and Multi Feature Flag Marshalling

### DIFF
--- a/backend/app/businessLayer/business.js
+++ b/backend/app/businessLayer/business.js
@@ -15,7 +15,7 @@ const launchDarklyFeatureFlagMarshal = require("./marshals/launchDarklyFeatureFl
 const getFeatureFlags = async () => {
   const data = await launchDarklyController.getFeatureFlags();
   const feature_flags =
-    launchDarklyFeatureFlagMarshal.launchDarklyFlagsMarshaller(data);
+    launchDarklyFeatureFlagMarshal.launchDarklyFlagMarshaller(data);
   return feature_flags;
 };
 

--- a/backend/app/businessLayer/marshals/launchDarklyFeatureFlagMarshal.js
+++ b/backend/app/businessLayer/marshals/launchDarklyFeatureFlagMarshal.js
@@ -7,55 +7,47 @@
 const FeatureFlag = require("../../../../shared/model/featureFlag");
 
 /**
- * Marshals an array of feature flag data from a LaunchDarkly JSON file.
+ * Marshals feature flag data into an array from a LaunchDarkly JSON file.
  *
  * @param {string} json_file - The LaunchDarkly JSON file.
- * @returns {Array} An array of marshalled feature flags.
+ * @returns {Array} An array of marshalled feature flags (or single flag).
  */
-launchDarklyFlagsMarshaller = (json_file) => {
+launchDarklyFlagMarshaller = (json_file) => {
   //parsifying the launch darkly json_file into an object
   const launch_darkly_json = JSON.parse(json_file);
 
   //creating feature flag array
   let feature_flags = [];
 
-  launch_darkly_json.items.forEach((item) => {
-    feature_flags.push(
-      new FeatureFlag(
-        item.key,
-        item.name,
-        item.environments.production.on,
-        new Date(item.environments.production.lastModified),
-        item.description
-      )
+  if (Array.isArray(launch_darkly_json.items)) {
+    // If request is multiple feature flags
+    launch_darkly_json.items.forEach((item) => {
+      feature_flags.push(
+        new FeatureFlag(
+          item.key,
+          item.name,
+          item.environments.production.on,
+          new Date(item.environments.production.lastModified),
+          item.description
+        )
+      );
+    });
+  } else {
+    // If request is a single feature flag
+    const feature_flag = new FeatureFlag(
+      launch_darkly_json.key,
+      launch_darkly_json.name,
+      launch_darkly_json.environments.production.on,
+      new Date(launch_darkly_json.environments.production.lastModified),
+      launch_darkly_json.description
     );
-  });
+
+    feature_flags.push(feature_flag);
+  }
 
   return feature_flags;
 };
 
-/**
- * Marshals a single feature flag data from a LaunchDarkly JSON file.
- *
- * @param {string} json_file - The LaunchDarkly JSON file.
- * @returns {Object} A feature flag object from the marshalled feature flag.
- */
-launchDarklyFlagMarshaller = (json_file) => {
-  //parsifying the launch darkly json_file into an object
-  const launch_darkly_json = JSON.parse(json_file);
-
-  const feature_flag = new FeatureFlag(
-    launch_darkly_json.key,
-    launch_darkly_json.name,
-    launch_darkly_json.environments.production.on,
-    new Date(launch_darkly_json.environments.production.lastModified),
-    launch_darkly_json.description
-  );
-
-  return feature_flag;
-};
-
 module.exports = {
   launchDarklyFlagMarshaller,
-  launchDarklyFlagsMarshaller,
 };


### PR DESCRIPTION
# launchDarklyFeatureFlagMarshal.js
- Combines previously separate marshalling functions for single feature flag and multi feature flag GET requests into one launchDarklyFlagMarshaller(json_file) function
- Logic checks if JSON.parse() object is an array, and returns an array of feature flag objects, or array of a single feature flag object
# business.js
- Updated with single function call to launchDarklyFlagMarshaller for both single and multi feature flag GET requests