### PR TITLE
Updated authentication keys for APIs

### DIFF
--- a/backend/app/featureFlagController/launchDarklyController.js
+++ b/backend/app/featureFlagController/launchDarklyController.js
@@ -13,7 +13,7 @@ async function getFeatureFlags(projectKey = "default") {
     {
       method: "GET",
       headers: {
-        Authorization: "api-b85a475e-50aa-4866-b376-a89bbefa98bb",
+        Authorization: "api-5ed283d6-d768-4a27-a478-92dc0f99c6aa",
       },
     }
   );
@@ -44,7 +44,7 @@ async function getFeatureFlag(parameters) {
     {
       method: "GET",
       headers: {
-        Authorization: "api-b85a475e-50aa-4866-b376-a89bbefa98bb",
+        Authorization: "api-5ed283d6-d768-4a27-a478-92dc0f99c6aa",
       },
     }
   );
@@ -76,7 +76,7 @@ async function changeFlag(parameters) {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        Authorization: "api-b85a475e-50aa-4866-b376-a89bbefa98bb",
+        Authorization: "api-5ed283d6-d768-4a27-a478-92dc0f99c6aa",
       },
       body: JSON.stringify({
         patch: [

--- a/clientUI/components/FeatureFlag/FeatureFlag.js
+++ b/clientUI/components/FeatureFlag/FeatureFlag.js
@@ -6,6 +6,8 @@ import Toggle from '../UI/Toggle'
 import Button from "../UI/button";
 
 export default function FeatureFlag(props) {
+  console.log("Rendered")
+  console.log(props.value)
 
   return (
     <React.Fragment>

--- a/clientUI/components/UI/Toggle.js
+++ b/clientUI/components/UI/Toggle.js
@@ -3,6 +3,8 @@ import classes from "../../styles/toggle.module.css";
 
 function Toggle(props) {
   const [toggleState, setToggleState] = useState(props.state);
+  console.log("Renrendered toggle")
+  console.log(toggleState)
 
   return (
     <React.Fragment>

--- a/clientUI/pages/feature-item/[featureId].js
+++ b/clientUI/pages/feature-item/[featureId].js
@@ -141,6 +141,7 @@ export default function FeaturePage() {
       }
     } catch (err) {
       fetchFeatureFlag();
+      console.log(flagPage.feature.value);
       alert("Saved Failed: "+ err.message);
       console.log(`Error ${err.message}`);
       

--- a/clientUI/pages/feature-item/[featureId].js
+++ b/clientUI/pages/feature-item/[featureId].js
@@ -11,11 +11,11 @@ const flagPageManager = (state, action) => {
   console.log(action.type);
   switch (action.type) {
     case "DATA_GATHERED":
-      console.log("entered data gathered");
+      //console.log("entered data gathered");
       {
         return {
           ...state,
-          toggleState: action.response.data.value,
+          toggleState: action.response.data[0].value,
           feature: new FeatureFlag(
             action.response.data[0].key,
             action.response.data[0].name,
@@ -27,7 +27,6 @@ const flagPageManager = (state, action) => {
         };
       }
     case "TOGGLE_CHANGED": {
-      console.log("Entered Toggle Changed");
       return {
         ...state,
         toggleState: !state.toggleState,
@@ -141,8 +140,10 @@ export default function FeaturePage() {
         alert("Saved Failed: "+ response.data.message);
       }
     } catch (err) {
+      fetchFeatureFlag();
       alert("Saved Failed: "+ err.message);
       console.log(`Error ${err.message}`);
+      
     }
   };
 

--- a/clientUI/pages/feature-item/[featureId].js
+++ b/clientUI/pages/feature-item/[featureId].js
@@ -136,10 +136,12 @@ export default function FeaturePage() {
           selection: "SAVED",
         });
         fetchFeatureFlag();
+        //If post is not successful
       } else {
-        alert(response.data.message);
+        alert("Saved Failed: "+ response.data.message);
       }
     } catch (err) {
+      alert("Saved Failed: "+ err.message);
       console.log(`Error ${err.message}`);
     }
   };


### PR DESCRIPTION
## Updated authentication keys 
New key: "api-5ed283d6-d768-4a27-a478-92dc0f99c6aa"

## Troubleshooting toggle state 
To re-enact the bug follow these steps:
1. Try to post from a feature flag unsuccessfully
2. Error alert will pop up saying that post was unsuccessful
3. The toggle SHOULD re-render to last state and not stay at the unsuccessfully changed state (which it is currently doing now)